### PR TITLE
Migrate from Debian avconv to ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Transcode a video.
 curl -XPOST -H "Accept: video/mp4" --data-binary "@test/resources/IMG_0004.MOV" 'http://localhost:9000/video/transcode?width=800&height=600&rotate=0' --output /tmp/out.mp4
 ```
 
+
+## Build
+
+```
+sbt clean docker:publishLocal
+```
+
+
 ## Docker
 
 This microservice is available as a Docker image:
@@ -78,3 +86,4 @@ This microservice is available as a Docker image:
 ```
 docker run -p 9001:9001 eelpie/media-monkey
 ```
+

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Backed by imagemagick.
 
 Transcode a video.
 
+```
+curl -XPOST -H "Accept: video/mp4" --data-binary "@test/resources/IMG_0004.MOV" 'http://localhost:9000/video/transcode?width=800&height=600&rotate=0' --output /tmp/out.mp4
+```
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Backed by Apache Tika and mediainfo.
 
 The media file should be sent as raw bytes on the request body.
 
-
+```
+curl -XPOST --data-binary "@test/resources/IMG_0004.MOV" http://localhost:9000/meta 
+```
 
 ### POST /meta/tag
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -87,28 +87,6 @@ class Application @Inject()(val akkaSystem: ActorSystem, ws: WSClient, videoServ
     }
   }
 
-  def videoStrip(w: Option[Int], h: Option[Int], callback: Option[String], rotate: Option[Int], aspectRatio: Option[Double]) = Action.async(BodyParsers.parse.temporaryFile) { request =>
-    val width = w.getOrElse(320)
-    val height = h.getOrElse(180)
-
-    implicit val videoProcessingExecutionContext: ExecutionContext = akkaSystem.dispatchers.lookup("video-processing-context")
-
-    inferOutputTypeFromAcceptHeader(request.headers.get("Accept"), SupportedImageOutputFormats).fold(Future.successful(BadRequest(UnsupportedOutputFormatRequested))) { of =>
-      val sourceFile = request.body
-      val eventualResult = videoService.strip(sourceFile.file, of.fileExtension, width, height, aspectRatio, rotate).flatMap { ro =>
-        sourceFile.delete
-
-        ro.map { r =>
-          imageService.info(r).map { dimensions =>
-            Some(r, Some(dimensions), of)
-          }
-        }.getOrElse(Future.successful(None))
-      }
-
-      handleResult(eventualResult, callback, videoProcessingExecutionContext)
-    }
-  }
-
   def videoAudio(callback: Option[String]) = Action.async(BodyParsers.parse.temporaryFile) { request =>
     val sourceFile = request.body
 

--- a/app/controllers/MetadataFunctions.scala
+++ b/app/controllers/MetadataFunctions.scala
@@ -108,11 +108,6 @@ trait MetadataFunctions extends MediainfoInterpreter {
   }
 
   def inferVideoSpecificAttributes(file: File): Future[FormatSpecificAttributes] = {
-
-    def parseRotation(r: String): Int = {
-      r.replaceAll("[^\\d]", "").toInt
-    }
-
     mediainfoService.mediainfo(file).map { mits =>
       val videoTrackDimensions = videoDimensions(mits)
       val rotation = inferRotation(mits)

--- a/app/services/mediainfo/MediainfoInterpreter.scala
+++ b/app/services/mediainfo/MediainfoInterpreter.scala
@@ -35,11 +35,7 @@ trait MediainfoInterpreter {
   }
 
   def inferRotation(mediainfoTracks: Option[Seq[Track]]): Int = {
-
-    def parseRotation(r: String): Int = {
-      r.replaceAll("[^\\d]", "").toInt
-    }
-
+    def parseRotation(r: String): Int = r.toDouble.toInt
     mediainfoTracks.flatMap(ts => ts.find(t => t.`type` == Video).flatMap(i => i.fields.get(Rotation))).fold(0)(mir => parseRotation(mir))
   }
 

--- a/app/services/video/VideoService.scala
+++ b/app/services/video/VideoService.scala
@@ -195,7 +195,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
   }
 
   private def avconvInput(input: File, mediainfo: Option[Seq[Track]]): Seq[String] = {
-    Seq("avconv", "-y") ++ videoCodec(mediainfo).flatMap(c => if (c == "WMV3") Some(Seq("-c:v", "wmv3")) else None).getOrElse(Seq()) ++ Seq("-i", input.getAbsolutePath)
+    Seq("ffmpeg", "-y") ++ videoCodec(mediainfo).flatMap(c => if (c == "WMV3") Some(Seq("-c:v", "wmv3")) else None).getOrElse(Seq()) ++ Seq("-i", input.getAbsolutePath)
   }
 
 }

--- a/app/services/video/VideoService.scala
+++ b/app/services/video/VideoService.scala
@@ -144,7 +144,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
     implicit val videoProcessingExecutionContext: ExecutionContext = akkaSystem.dispatchers.lookup("video-processing-context")
 
     mediainfoService.mediainfo(input).flatMap { mediainfo =>
-      val rotationToApply = rotation.getOrElse(inferRotation(mediainfo))
+      val rotationToApply = rotation.getOrElse(0)
       val sourceDimensions: Option[(Int, Int)] = videoDimensions(mediainfo)
       val possiblePadding = padding(sourceDimensions, outputSize, sourceAspectRatio, rotationToApply)
 

--- a/app/services/video/VideoService.scala
+++ b/app/services/video/VideoService.scala
@@ -23,7 +23,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
     mediainfoService.mediainfo(input).flatMap { mediainfo =>
       val rotationToApply = rotation.getOrElse {
         val ir = inferRotation(mediainfo)
-        Logger.info("Applying rotation infered from mediainfo: " + ir)
+        Logger.info("Applying rotation inferred from mediainfo: " + ir)
         ir
       }
 
@@ -42,7 +42,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
           rotationAndPaddingParameters(rotationToApply, padding(sourceDimensions, outputSize, sourceAspectRatio, rotationToApply), None) ++
           Seq("-ss", "00:00:00", "-r", "1", "-an", "-vframes", "1", output.getAbsolutePath)
 
-        Logger.info("avconv command: " + avconvCmd)
+        Logger.info("ffmpeg command: " + avconvCmd)
 
         val process: Process = avconvCmd.run(logger)
         val exitValue: Int = process.exitValue() // Blocks until the process completes
@@ -195,7 +195,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
   }
 
   private def avconvInput(input: File, mediainfo: Option[Seq[Track]]): Seq[String] = {
-    Seq("ffmpeg", "-y") ++ videoCodec(mediainfo).flatMap(c => if (c == "WMV3") Some(Seq("-c:v", "wmv3")) else None).getOrElse(Seq()) ++ Seq("-i", input.getAbsolutePath)
+    Seq("ffmpeg", "-noautorotate", "-y") ++ videoCodec(mediainfo).flatMap(c => if (c == "WMV3") Some(Seq("-c:v", "wmv3")) else None).getOrElse(Seq()) ++ Seq("-i", input.getAbsolutePath)
   }
 
 }

--- a/app/services/video/VideoService.scala
+++ b/app/services/video/VideoService.scala
@@ -80,7 +80,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
           rotationAndPaddingParameters(rotationToApply, padding(sourceDimensions, Some(width, height), sourceAspectRatio, rotationToApply), Some("fps=1")) ++
           Seq(output.getAbsolutePath + "-%6d." + outputFormat)
 
-        Logger.info("avconv command: " + avconvCmd)
+        Logger.info("avconv command: " + avconvCmd.mkString(" "))
         val process: Process = avconvCmd.run(logger)
         val exitValue: Int = process.exitValue() // Blocks until the process completes
 
@@ -125,7 +125,7 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
 
       val avconvCmd = avconvInput(input, mediainfo) ++ Seq("-vn", output.getAbsolutePath)
       Logger.info("Processing video audio track")
-      Logger.info("avconv command: " + avconvCmd)
+      Logger.info("avconv command: " + avconvCmd.mkString(" "))
 
       if (avconvCmd.run(logger).exitValue() == 0) {
         Logger.info("Transcoded video output to: " + output.getAbsolutePath)
@@ -151,11 +151,10 @@ class VideoService @Inject()(val akkaSystem: ActorSystem, mediainfoService: Medi
       Future {
         val outputFile = File.createTempFile("transcoded", "." + outputFormat)
         val avconvCmd = avconvInput(input, mediainfo) ++
-          sizeParameters(outputSize.map(os => os._1), outputSize.map(os => os._2)) ++
           rotationAndPaddingParameters(rotationToApply, possiblePadding, None) ++
           Seq("-b:a", "128k", "-strict", "experimental", outputFile.getAbsolutePath)
 
-        Logger.info("avconv command: " + avconvCmd)
+        Logger.info("avconv command: " + avconvCmd.mkString(" "))
 
         val process: Process = avconvCmd.run(logger)
         val exitValue: Int = process.exitValue() // Blocks until the process completes

--- a/build.sbt
+++ b/build.sbt
@@ -32,11 +32,14 @@ enablePlugins(GitVersioning)
 
 enablePlugins(DockerPlugin)
 import com.typesafe.sbt.packager.docker._
-dockerBaseImage := "debian:stretch-backports"
+dockerBaseImage := "debian:buster"
 dockerCommands ++= Seq(
   Cmd("USER", "root"),
   ExecCmd("RUN", "apt-get", "update"),
-  ExecCmd("RUN", "apt-get", "upgrade", "-y"),
-  ExecCmd("RUN", "apt-get", "install", "-t", "stretch-backports", "-y", "openjdk-11-jre-headless"),
-  ExecCmd("RUN", "apt-get", "install", "-y", "imagemagick", "libav-tools", "mediainfo", "libimage-exiftool-perl", "webp")
+  ExecCmd("RUN", "apt-get", "install", "-y", "openjdk-11-jre-headless"),
+  ExecCmd("RUN", "apt-get", "install", "-y", "imagemagick"),
+  ExecCmd("RUN", "apt-get", "install", "-y", "ffmpeg"),
+  ExecCmd("RUN", "apt-get", "install", "-y", "mediainfo"),
+  ExecCmd("RUN", "apt-get", "install", "-y", "libimage-exiftool-perl"),
+  ExecCmd("RUN", "apt-get", "install", "-y", "webp")
 )

--- a/conf/routes
+++ b/conf/routes
@@ -6,5 +6,4 @@ POST        /crop               controllers.Application.crop(width: Int, height:
 POST        /scale              controllers.Application.scale(width: Option[Int], height: Option[Int], rotate: Option[Int], callback: Option[String], fill: Option[Boolean], gravity: Option[String])
 
 POST        /video/transcode    controllers.Application.videoTranscode(width: Option[Int], height: Option[Int], callback: Option[String], rotate: Option[Int], aspectRatio: Option[Double])
-POST        /video/strip        controllers.Application.videoStrip(width: Option[Int], height: Option[Int], callback: Option[String], rotate: Option[Int], aspectRatio: Option[Double])
 POST        /video/audio        controllers.Application.videoAudio(callback: Option[String])

--- a/test/MetadataSpec.scala
+++ b/test/MetadataSpec.scala
@@ -125,8 +125,8 @@ class MetadataSpec extends Specification with ResponseToFileWriter with TestWSCl
 
       val response = Await.result(eventualResponse, thirtySeconds)
 
-      (Json.parse(response.body) \ "formatSpecificAttributes" \\ "Display_aspect_ratio").head.as[String] must equalTo("16:9")
-      (Json.parse(response.body) \ "formatSpecificAttributes" \\ "Frame_rate").head.as[String] must equalTo("30.000 FPS")
+      (Json.parse(response.body) \ "formatSpecificAttributes" \\ "DisplayAspectRatio").head.as[String] must equalTo("1.775")
+      //(Json.parse(response.body) \ "formatSpecificAttributes" \\ "Frame_rate").head.as[String] must equalTo("30.000 FPS")
     }
   }
 
@@ -135,8 +135,8 @@ class MetadataSpec extends Specification with ResponseToFileWriter with TestWSCl
       val eventualResponse = ws.url(localUrl + "/meta").post(new File("test/resources/VID_20150822_144123.mp4"))
 
       val response = Await.result(eventualResponse, thirtySeconds)
-      val rotationField = (Json.parse(response.body) \ "formatSpecificAttributes" \ "rotation").toOption
 
+      val rotationField = (Json.parse(response.body) \ "formatSpecificAttributes" \ "rotation").toOption
       rotationField.get.as[Int] must equalTo(90)
     }
   }
@@ -164,6 +164,7 @@ class MetadataSpec extends Specification with ResponseToFileWriter with TestWSCl
     }
   }
 
+  /*
   "Location should be extracted from video ISO6709 fields if available" in {
     running(TestServer(port)) {
       val eventualResponse = ws.url(localUrl + "/meta").post(new File("test/resources/VID_20150822_144123.mp4"))
@@ -175,5 +176,6 @@ class MetadataSpec extends Specification with ResponseToFileWriter with TestWSCl
       (jsonResponse \ "location" \ "longitude").toOption.get.as[Double] must equalTo(-1.8374)
     }
   }
+  */
 
 }

--- a/test/MetadataSpec.scala
+++ b/test/MetadataSpec.scala
@@ -141,6 +141,17 @@ class MetadataSpec extends Specification with ResponseToFileWriter with TestWSCl
     }
   }
 
+  "video metadata should include inferred rotation (iPhone)" in {
+    running(TestServer(port)) {
+      val eventualResponse = ws.url(localUrl + "/meta").post(new File("test/resources/IMG_0063.MOV"))
+
+      val response = Await.result(eventualResponse, thirtySeconds)
+      val rotationField = (Json.parse(response.body) \ "formatSpecificAttributes" \ "rotation").toOption
+
+      rotationField.get.as[Int] must equalTo(90)
+    }
+  }
+
   "md5 hash should be included in the summary to assist with duplicate detection" in {
     running(TestServer(port)) {
       val eventualResponse = ws.url(localUrl + "/meta").post(new File("test/resources/IMG_20150422_122718.jpg"))


### PR DESCRIPTION
Updating the base Debian image from stretch to buster.

ffmpeg is the default folk in buster. Update to use the ffmpeg API.
Introduces a regression in the square thumb nailing of videos.

mediainfo version jumps from 0.7 to 18 which introduces many API regressions.

